### PR TITLE
go.mod: Update gopkg.in/yaml.v2 to v2.4.0

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // dateFormat is the format used for the `since` configuration parameter
@@ -354,7 +354,7 @@ func (c *Config) validateConfig() error {
 		jPass := c.cmdConfig.GetString("jira-pass")
 		if jPass == "" {
 			fmt.Print("Enter your JIRA password: ")
-			bytePass, err := terminal.ReadPassword(int(syscall.Stdin))
+			bytePass, err := term.ReadPassword(int(syscall.Stdin))
 			if err != nil {
 				return errors.New("JIRA password required")
 			}

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/spf13/cobra v0.0.0-20170716104802-d994347edadc
 	github.com/spf13/viper v1.14.0
-	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 )
 
 require (
@@ -33,7 +33,6 @@ require (
 	github.com/trivago/tgo v0.0.0-20170714134939-8a6fc6a04f07 // indirect
 	golang.org/x/net v0.0.0-20221014081412-f15817d10f9b // indirect
 	golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.4.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,6 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
-golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=


### PR DESCRIPTION
Fixes https://github.com/uwu-tools/gh-jira-sync/security/dependabot/1 / https://github.com/advisories/GHSA-wxc4-f4m6-wwqv

- go.mod: Update github.com/spf13/viper to v1.14.0
- go.mod: golang.org/x/crypto/ssh/terminal is deprecated

Signed-off-by: Stephen Augustus <foo@auggie.dev>